### PR TITLE
chore: export type and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,16 @@ In this phase, we use OAuth2 with Hydra for authentication.
 1. Follow the [Hydra documentation](https://service-auth.deriv.team/resources/hydra-qa-setup/) to set up Hydra in QA box environment.
 2. Configure your OAuth2 settings in the project.
 
-### Using the OAuth2 Provider
+### Using the OAuth2 Hook
 
 Use the `useOAuth2` hook within your components.
 
 ```typescript
-// src/App.tsx
 import React from 'react';
-import { useOAuth2 } from '@deriv-com/auth-client';
+import { useOAuth2, TOAuth2EnabledAppList } from '@deriv-com/auth-client';
 
 const YourComponent = () => {
-     const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<hydraBEApps>({
+     const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<TOAuth2EnabledAppList>({
         featureFlag: 'hydra_be',
     });
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useOAuth2 } from './useOAuth2';
 export { useIsOAuth2Enabled } from './useIsOAuth2Enabled';
+export type { TOAuth2EnabledAppList } from './useOAuth2';

--- a/src/hooks/useOAuth2.ts
+++ b/src/hooks/useOAuth2.ts
@@ -7,12 +7,12 @@ type MessageEvent = {
     origin: string;
 };
 
-type hydraBEApps = {
+export type TOAuth2EnabledAppList = {
     enabled_for: number[];
-};
+}[];
 
 type OAuth2GBConfig = {
-    OAuth2EnabledApps: hydraBEApps[];
+    OAuth2EnabledApps: TOAuth2EnabledAppList;
     OAuth2EnabledAppsInitialised: boolean;
 };
 


### PR DESCRIPTION
## Description

### Motivation
1. Every app has to create their own type for the growthbook feature flag value. 

### Actions
1. Exported the type so every consumer app can just import it instead of creating their own. 

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] This change requires a documentation update
