### PR TITLE
chore: add fallback to the server url

### DIFF
--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -29,7 +29,10 @@ export const getServerInfo = () => {
         );
     }
 
-    const storedServerUrl = LocalStorageUtils.getValue<string>(LocalStorageConstants.configServerURL);
+    const storedServerUrl =
+        LocalStorageUtils.getValue<string>(LocalStorageConstants.configServerURL) ||
+        localStorage.getItem('config.server_url');
+
     const serverUrl = /qa/.test(String(storedServerUrl)) ? storedServerUrl : 'oauth.deriv.com';
 
     const appId = LocalStorageUtils.getValue<string>(LocalStorageConstants.configAppId);


### PR DESCRIPTION
## Description

### Motivation
 const storedServerUrl =
        LocalStorageUtils.getValue<string>(LocalStorageConstants.configServerURL) was returning null

### Actions
1. Added a fallback to read from localstorage directly without using utils package

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update
