### PR TITLE
Clear timeout once we get logout_complete

### DIFF
--- a/src/hooks/useOAuth2.ts
+++ b/src/hooks/useOAuth2.ts
@@ -27,7 +27,7 @@ export const useOAuth2 = (OAuth2GrowthBookConfig: OAuth2GBConfig, WSLogoutAndRed
     const { OAuth2EnabledApps, OAuth2EnabledAppsInitialised } = OAuth2GrowthBookConfig;
     const isOAuth2Enabled = useIsOAuth2Enabled(OAuth2EnabledApps, OAuth2EnabledAppsInitialised);
 
-    const intervalRef = useRef()
+    const timeoutRef = useRef()
 
     useEffect(() => {
         if (!isOAuth2Enabled) return;
@@ -37,8 +37,8 @@ export const useOAuth2 = (OAuth2GrowthBookConfig: OAuth2GBConfig, WSLogoutAndRed
             if (allowedOrigin === event.origin) {
                 if (event.data === 'logout_complete') {
                     console.warn("logout completed")
-                    if (intervalRef.current) {
-                        clearInterval(intervalRef.current);
+                    if (timeoutRef.current) {
+                        clearInterval(timeoutRef.current)
                     }
                     await WSLogoutAndRedirect();
                 } else {
@@ -66,7 +66,7 @@ export const useOAuth2 = (OAuth2GrowthBookConfig: OAuth2GBConfig, WSLogoutAndRed
             iframe.style.display = 'none';
             document.body.appendChild(iframe);
 
-            intervalRef.current = setInterval(async () => {
+            timeoutRef.current = setTimeout(async () => {
                 await WSLogoutAndRedirect();
             }, 10000);
         }

--- a/src/hooks/useOAuth2.ts
+++ b/src/hooks/useOAuth2.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { getOAuthLogoutUrl, getOAuthOrigin } from '../constants/';
 import { useIsOAuth2Enabled } from './useIsOAuth2Enabled';
 
@@ -27,6 +27,8 @@ export const useOAuth2 = (OAuth2GrowthBookConfig: OAuth2GBConfig, WSLogoutAndRed
     const { OAuth2EnabledApps, OAuth2EnabledAppsInitialised } = OAuth2GrowthBookConfig;
     const isOAuth2Enabled = useIsOAuth2Enabled(OAuth2EnabledApps, OAuth2EnabledAppsInitialised);
 
+    const intervalRef = useRef()
+
     useEffect(() => {
         if (!isOAuth2Enabled) return;
 
@@ -35,6 +37,9 @@ export const useOAuth2 = (OAuth2GrowthBookConfig: OAuth2GBConfig, WSLogoutAndRed
             if (allowedOrigin === event.origin) {
                 if (event.data === 'logout_complete') {
                     console.warn("logout completed")
+                    if (intervalRef.current) {
+                        clearInterval(intervalRef.current);
+                    }
                     await WSLogoutAndRedirect();
                 } else {
                     console.warn('Unexpected message received: ', event.data);
@@ -61,7 +66,7 @@ export const useOAuth2 = (OAuth2GrowthBookConfig: OAuth2GBConfig, WSLogoutAndRed
             iframe.style.display = 'none';
             document.body.appendChild(iframe);
 
-            setTimeout(async () => {
+            intervalRef.current = setInterval(async () => {
                 await WSLogoutAndRedirect();
             }, 10000);
         }


### PR DESCRIPTION
## Description
Currently we are debugging Deriv-app where logout takes longer as expected, thus we are clearing setTimeout once we receive the logout_complete from the iframe

### Motivation

Please include the motivation behind this change. Why is this change required? What problem does it solve?

### Actions

List the actions taken to achieve this change. What steps were followed? What was modified?

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update
