### PR TITLE
chore: get app id from utils package as fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@deriv-com/auth-client",
             "version": "0.0.0-development",
             "dependencies": {
-                "@deriv-com/utils": "^0.0.33",
+                "@deriv-com/utils": "^0.0.37",
                 "oidc-client-ts": "^3.1.0"
             },
             "devDependencies": {
@@ -441,9 +441,9 @@
             }
         },
         "node_modules/@deriv-com/utils": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.33.tgz",
-            "integrity": "sha512-LzIpzMvfWhK9y06Qpe/HOB4pFCizk2wAyhv9I0s48Romq+d5MM1mmsuh5CvS4SnzzdLyuBy4rgXrOO3394HB7w=="
+            "version": "0.0.37",
+            "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.37.tgz",
+            "integrity": "sha512-+ngUvT+OqwblBoqkHcsbLtljjwOGIjjMpo5xLS5fwyhtNvBe8Rcq+140QV1j0xq9vlm2kmcowEKIVBq33imFmg=="
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "access": "public"
     },
     "dependencies": {
-        "@deriv-com/utils": "^0.0.33",
+        "@deriv-com/utils": "^0.0.37",
         "oidc-client-ts": "^3.1.0"
     },
     "devDependencies": {

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,4 +1,11 @@
-import { AppIDConstants, LocalStorageConstants, LocalStorageUtils, URLConstants, URLUtils } from '@deriv-com/utils';
+import {
+    AppIDConstants,
+    LocalStorageConstants,
+    LocalStorageUtils,
+    URLConstants,
+    URLUtils,
+    WebSocketUtils,
+} from '@deriv-com/utils';
 
 export const DEFAULT_OAUTH_LOGOUT_URL = 'https://oauth.deriv.com/oauth2/sessions/logout';
 
@@ -12,6 +19,9 @@ const SocketURL = {
 export const getServerInfo = () => {
     const origin = window.location.origin;
     const hostname = window.location.hostname;
+    const { getAppId } = WebSocketUtils;
+
+    const appIdFromUtils = getAppId();
 
     const existingAppId = LocalStorageUtils.getValue<string>(LocalStorageConstants.configAppId);
     const existingServerUrl = LocalStorageUtils.getValue<string>(LocalStorageConstants.configServerURL);
@@ -35,7 +45,7 @@ export const getServerInfo = () => {
 
     const serverUrl = /qa/.test(String(storedServerUrl)) ? storedServerUrl : 'oauth.deriv.com';
 
-    const appId = LocalStorageUtils.getValue<string>(LocalStorageConstants.configAppId);
+    const appId = LocalStorageUtils.getValue<string>(LocalStorageConstants.configAppId) || appIdFromUtils;
     const lang = LocalStorageUtils.getValue<string>(LocalStorageConstants.i18nLanguage);
 
     return {


### PR DESCRIPTION
## Description

### Motivation
1. The app id is not being set in the consumer projects on first load till they click submit in the endpoint page

### Actions
1. Get the app id from the utils package

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update
