### PR TITLE
chore: add oidc logout function to replace the iframe logic

### DIFF
--- a/src/oidc/oidc.ts
+++ b/src/oidc/oidc.ts
@@ -346,7 +346,7 @@ export const oidcLogout = async (options: RequestOidcAuthenticationOptions): Pro
         });
     } catch (error) {
         console.error('Error during logout:', error);
-        throw error;
+        throw new Error(`Logout failed. ${error}`);
     }
 };
 


### PR DESCRIPTION
## Description
### Motivation
1. Currently in production we have an iframe to `/sessions/logout`. 
2. Since we are using oidc-client-ts library now, we have to manually send the id_token as query payload to the end_session_endpoint.

### Actions
1. Used the signoutRedirect function coming from the oidc-client-ts library which handles the redirection of the `end_session_endpoint` which is the `/sessions/logout`. 
3. This library also handles the auth cookie clear and the sessionStorage clear of the oidc session we have from login. 

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] This change requires a documentation update
