### PR TITLE
Adrienne / Disable automatic silent renew

### DIFF
--- a/src/oidc/oidc.ts
+++ b/src/oidc/oidc.ts
@@ -270,6 +270,10 @@ export const createUserManager = async (options: CreateUserManagerOptions) => {
             scope: 'openid',
             stateStore: new WebStorageStateStore({ store: window.localStorage }),
             post_logout_redirect_uri: _postLogoutRedirectUri,
+            // this is enabled by default, it runs a silent renew service in the background which triggers the prompt=none auth calls
+            // Source: https://github.com/authts/oidc-client-ts/blob/9ccae8f87b3e9e2df349aaf6f007964ced287b02/src/UserManagerSettings.ts#L140
+            // Notable issue: https://github.com/authts/oidc-client-ts/issues/1174
+            automaticSilentRenew: false,
         });
         return userManager;
     } catch (error) {
@@ -392,6 +396,7 @@ export const clearOIDCStorage = async (options: ClearOIDCStorageOptions) => {
         const userManager = await createUserManager(options);
 
         await userManager.removeUser();
+        await userManager.clearStaleState();
     } catch (error) {
         if (error instanceof Error) throw new OIDCError(OIDCErrorType.FailedToRemoveSession, error.message);
         throw new OIDCError(OIDCErrorType.FailedToRemoveSession, 'unable to remove OIDC session');


### PR DESCRIPTION
## Description
The `prompt=none` issue could be triggered by a silent renew which is enabled by default in `oidc-client-ts` new version.
<img width="827" alt="Screenshot 2025-02-08 at 3 47 01 PM" src="https://github.com/user-attachments/assets/d9cc1f57-13aa-4ac4-bbfb-d1e89ff48a88" />
<img width="1005" alt="Screenshot 2025-02-08 at 3 47 22 PM" src="https://github.com/user-attachments/assets/b4509b8e-631e-4a22-b7b9-4ac568a0b750" />

It starts a silentRenewService which, after logout and our access tokens expired, will trigger a silent renew attempt:
<img width="948" alt="Screenshot 2025-02-08 at 3 36 23 PM" src="https://github.com/user-attachments/assets/44e5c21f-0e90-49e5-a8fc-dbdaeccfad56" />

<img width="687" alt="Screenshot 2025-02-08 at 3 37 10 PM" src="https://github.com/user-attachments/assets/671ab072-4ecd-4faa-b5cc-2d2f8fbe0dba" />



### Motivation

Please include the motivation behind this change. Why is this change required? What problem does it solve?

### Actions

List the actions taken to achieve this change. What steps were followed? What was modified?

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update
